### PR TITLE
Adds option to disable team collection (for accounts that don't include the 'team' feature)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Normally no configuration is needed but can be customized using environment vari
 | `PAGERDUTY_SCHEDULE_ENTRY_TIMEFRAME`    | `72h`                       | PagerDuty schedule rendered list timeframe                               |
 | `PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT`   | `Mon, 02 Jan 15:04 MST`     | PagerDuty schedule entry timeformat (label)                              |
 | `PAGERDUTY_INCIDENT_TIMEFORMAT`         | `Mon, 02 Jan 15:04 MST`     | PagerDuty incident entry timeformat (label)                              |
+| `PAGERDUTY_DISABLE_TEAMS`               | `false`                     | Boolean (set to 'true' to skip collecting "team" data)                   |
 
 Metrics
 -------

--- a/src/main.go
+++ b/src/main.go
@@ -41,6 +41,7 @@ var opts struct {
 	PagerDutyScheduleEntryTimeframe    time.Duration `long:"pagerduty.schedule.entry-timeframe"      env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFRAME"           description:"PagerDuty timeframe for fetching schedule entries (time.Duration)" default:"72h"`
 	PagerDutyScheduleEntryTimeFormat   string        `long:"pagerduty.schedule.entry-timeformat"           env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT"          description:"PagerDuty schedule entry time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyIncidentTimeFormat        string        `long:"pagerduty.incident.timeformat"                      env:"PAGERDUTY_INCIDENT_TIMEFORMAT"                description:"PagerDuty incident time format (label)" default:"Mon, 02 Jan 15:04 MST"`
+	PagerDutyDisableTeams              bool          `long:"pagerduty.disable-teams"                description:"Set to true to disable checking PagerDuty teams (for plans that don't include it)"                env:"PAGERDUTY_DISABLE_TEAMS"`
 }
 
 func main() {
@@ -94,12 +95,14 @@ func initMetricCollector() {
 	var collectorName string
 	collectorGeneralList = map[string]*CollectorGeneral{}
 
-	collectorName = "Team"
-	if opts.ScrapeTime.Seconds() > 0 {
-		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorTeam{})
-		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
-	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+	if !opts.PagerDutyDisableTeams {
+		collectorName = "Team"
+		if opts.ScrapeTime.Seconds() > 0 {
+			collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorTeam{})
+			collectorGeneralList[collectorName].Run(opts.ScrapeTime)
+		} else {
+			Logger.Infof("collector[%s]: disabled", collectorName)
+		}
 	}
 
 	collectorName = "User"

--- a/src/metrics_service.go
+++ b/src/metrics_service.go
@@ -55,11 +55,20 @@ func (m *MetricsCollectorService) Collect(ctx context.Context, callback chan<- f
 		}
 
 		for _, service := range list.Services {
-			for _, team := range service.Teams {
+			if len(service.Teams) > 0 {
+				for _, team := range service.Teams {
 
+					serviceMetricList.AddInfo(prometheus.Labels{
+						"serviceID":   service.ID,
+						"teamID":      team.ID,
+						"serviceName": service.Name,
+						"serviceUrl":  service.HTMLURL,
+					})
+				}
+			} else {
 				serviceMetricList.AddInfo(prometheus.Labels{
 					"serviceID":   service.ID,
-					"teamID":      team.ID,
+					"teamID":      "",
 					"serviceName": service.Name,
 					"serviceUrl":  service.HTMLURL,
 				})


### PR DESCRIPTION
This adds an option to disable calling the 'team' API. For accounts on a pricing plan where the 'teams' feature isn't included, using this flag fixes the following error:
```
panic: Failed call API endpoint. HTTP response code: 402. Error: &{2014 Required abilities are unavailable [The teams account ability is required to access teams]}
```