### PR TITLE
Adding team list opt parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Normally no configuration is needed but can be customized using environment vari
 | `PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT`   | `Mon, 02 Jan 15:04 MST`     | PagerDuty schedule entry timeformat (label)                              |
 | `PAGERDUTY_INCIDENT_TIMEFORMAT`         | `Mon, 02 Jan 15:04 MST`     | PagerDuty incident entry timeformat (label)                              |
 | `PAGERDUTY_DISABLE_TEAMS`               | `false`                     | Boolean (set to 'true' to skip collecting "team" data)                   |
-| `PAGERDUTY_TEAM_LISTOPT`                | none                        | Comma delimited list of Team IDs to pass to list options when applicable |
+| `PAGERDUTY_TEAM_FILTER`                 | none                        | Comma delimited list of Team IDs to pass to list options when applicable |
 
 Metrics
 -------

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Normally no configuration is needed but can be customized using environment vari
 | `PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT`   | `Mon, 02 Jan 15:04 MST`     | PagerDuty schedule entry timeformat (label)                              |
 | `PAGERDUTY_INCIDENT_TIMEFORMAT`         | `Mon, 02 Jan 15:04 MST`     | PagerDuty incident entry timeformat (label)                              |
 | `PAGERDUTY_DISABLE_TEAMS`               | `false`                     | Boolean (set to 'true' to skip collecting "team" data)                   |
+| `PAGERDUTY_TEAM_LISTOPT`                | none                        | Comma delimited list of Team IDs to pass to list options when applicable |
 
 Metrics
 -------

--- a/main.go
+++ b/main.go
@@ -2,13 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/jessevdk/go-flags"
 	"github.com/PagerDuty/go-pagerduty"
+	"github.com/jessevdk/go-flags"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"log"
 	"net/http"
 	"os"
-	"strings"
 	"time"
 )
 
@@ -43,7 +42,7 @@ var opts struct {
 	PagerDutyScheduleEntryTimeFormat   string        `long:"pagerduty.schedule.entry-timeformat"           env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT"          description:"PagerDuty schedule entry time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyIncidentTimeFormat        string        `long:"pagerduty.incident.timeformat"                      env:"PAGERDUTY_INCIDENT_TIMEFORMAT"                description:"PagerDuty incident time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyDisableTeams              bool          `long:"pagerduty.disable-teams"                description:"Set to true to disable checking PagerDuty teams (for plans that don't include it)"                env:"PAGERDUTY_DISABLE_TEAMS"`
-	PagerDutyTeamListOpt			   []string      `long:"pagerduty.team-listopt"                 env:"PAGERDUTY_TEAM_LISTOPT"            description:"Passes team ID as a list option when applicable."`
+	PagerDutyTeamFilter			       []string      `long:"pagerduty.team-filter" env-delim:","                env:"PAGERDUTY_TEAM_FILTER"            description:"Passes team ID as a list option when applicable."`
 }
 
 func main() {
@@ -97,12 +96,6 @@ func initMetricCollector() {
 	var collectorName string
 	collectorGeneralList = map[string]*CollectorGeneral{}
 
-	// necessary step to properly parse comma delimited env var value
-	var teamListOpts []string
-	if len(opts.PagerDutyTeamListOpt) == 1 {
-		teamListOpts = strings.Split(opts.PagerDutyTeamListOpt[0], ",")
-	}
-
 	if !opts.PagerDutyDisableTeams {
 		collectorName = "Team"
 		if opts.ScrapeTime.Seconds() > 0 {
@@ -115,7 +108,7 @@ func initMetricCollector() {
 
 	collectorName = "User"
 	if opts.ScrapeTime.Seconds() > 0 {
-		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorUser{teamListOpt: teamListOpts})
+		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorUser{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
 		Logger.Infof("collector[%s]: disabled", collectorName)
@@ -123,7 +116,7 @@ func initMetricCollector() {
 
 	collectorName = "Service"
 	if opts.ScrapeTime.Seconds() > 0 {
-		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorService{teamListOpt: teamListOpts})
+		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorService{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
 		Logger.Infof("collector[%s]: disabled", collectorName)
@@ -139,7 +132,7 @@ func initMetricCollector() {
 
 	collectorName = "MaintenanceWindow"
 	if opts.ScrapeTime.Seconds() > 0 {
-		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorMaintenanceWindow{teamListOpt: teamListOpts})
+		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorMaintenanceWindow{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
 		Logger.Infof("collector[%s]: disabled", collectorName)
@@ -155,7 +148,7 @@ func initMetricCollector() {
 
 	collectorName = "Incident"
 	if opts.ScrapeTimeLive.Seconds() > 0 {
-		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorIncident{teamListOpt: teamListOpts})
+		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorIncident{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTimeLive)
 	} else {
 		Logger.Infof("collector[%s]: disabled", collectorName)

--- a/metrics_incident.go
+++ b/metrics_incident.go
@@ -14,6 +14,8 @@ type MetricsCollectorIncident struct {
 		incident       *prometheus.GaugeVec
 		incidentStatus *prometheus.GaugeVec
 	}
+
+	teamListOpt []string
 }
 
 func (m *MetricsCollectorIncident) Setup(collector *CollectorGeneral) {
@@ -66,6 +68,10 @@ func (m *MetricsCollectorIncident) Collect(ctx context.Context, callback chan<- 
 	listOpts.Limit = PAGERDUTY_LIST_LIMIT
 	listOpts.Statuses = []string{"triggered", "acknowledged"}
 	listOpts.Offset = 0
+
+	if len(m.teamListOpt) > 0 {
+		listOpts.TeamIDs = m.teamListOpt
+	}
 
 	incidentMetricList := MetricCollectorList{}
 	incidentStatusMetricList := MetricCollectorList{}

--- a/metrics_maintenance_window.go
+++ b/metrics_maintenance_window.go
@@ -14,6 +14,8 @@ type MetricsCollectorMaintenanceWindow struct {
 		maintenanceWindow       *prometheus.GaugeVec
 		maintenanceWindowStatus *prometheus.GaugeVec
 	}
+
+	teamListOpt []string
 }
 
 func (m *MetricsCollectorMaintenanceWindow) Setup(collector *CollectorGeneral) {
@@ -55,6 +57,10 @@ func (m *MetricsCollectorMaintenanceWindow) Collect(ctx context.Context, callbac
 	listOpts := pagerduty.ListMaintenanceWindowsOptions{}
 	listOpts.Limit = PAGERDUTY_LIST_LIMIT
 	listOpts.Offset = 0
+
+	if len(m.teamListOpt) > 0 {
+		listOpts.TeamIDs = m.teamListOpt
+	}
 
 	maintWindowMetricList := MetricCollectorList{}
 	maintWindowsStatusMetricList := MetricCollectorList{}

--- a/metrics_service.go
+++ b/metrics_service.go
@@ -12,6 +12,8 @@ type MetricsCollectorService struct {
 	prometheus struct {
 		service *prometheus.GaugeVec
 	}
+
+	teamListOpt []string
 }
 
 func (m *MetricsCollectorService) Setup(collector *CollectorGeneral) {
@@ -41,6 +43,10 @@ func (m *MetricsCollectorService) Collect(ctx context.Context, callback chan<- f
 	listOpts := pagerduty.ListServiceOptions{}
 	listOpts.Limit = PAGERDUTY_LIST_LIMIT
 	listOpts.Offset = 0
+
+	if len(m.teamListOpt) > 0 {
+		listOpts.TeamIDs = m.teamListOpt
+	}
 
 	serviceMetricList := MetricCollectorList{}
 

--- a/metrics_user.go
+++ b/metrics_user.go
@@ -12,6 +12,8 @@ type MetricsCollectorUser struct {
 	prometheus struct {
 		user *prometheus.GaugeVec
 	}
+
+	teamListOpt []string
 }
 
 func (m *MetricsCollectorUser) Setup(collector *CollectorGeneral) {
@@ -45,6 +47,10 @@ func (m *MetricsCollectorUser) Collect(ctx context.Context, callback chan<- func
 	listOpts := pagerduty.ListUsersOptions{}
 	listOpts.Limit = PAGERDUTY_LIST_LIMIT
 	listOpts.Offset = 0
+
+	if len(m.teamListOpt) > 0 {
+		listOpts.TeamIDs = m.teamListOpt
+	}
 
 	userMetricList := MetricCollectorList{}
 


### PR DESCRIPTION
This PR implements features that allow for team specific scraping and #3 .

Once passing a list of team IDs through env vars or a flag, all queries that have the `teamListOpt` feature will use the previously mentioned parameter.

I noticed weird behavior with go flags when parsing a comma delimited list through env vars. It will parse the whole list (regardless of length) as a single element in an array of length 1.

```
	if len(opts.PagerDutyTeamListOpt) == 1 {
		teamListOpts = strings.Split(opts.PagerDutyTeamListOpt[0], ",")
	}
```

This code defined above handles this case and does not break when actually passing in an list of team opts of length 1.