### PR TITLE
Add Makefile and remove unused imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,37 @@
+.PHONY: all build clean image check vendor dependencies
+
+NAME				:= pagerduty-exporter
+TAG					:= $(shell git rev-parse --short HEAD)
+
+PKGS				:= $(shell go list ./... | grep -v -E '/vendor/|/test')
+FIRST_GOPATH		:= $(firstword $(subst :, ,$(shell go env GOPATH)))
+GOLANGCI_LINT_BIN	:= $(FIRST_GOPATH)/bin/golangci-lint
+
+
+all: build
+
+clean:
+	git clean -Xfd .
+
+build:
+	CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o $(NAME) .
+
+vendor:
+	go mod tidy
+	go mod vendor
+	go mod verify
+
+image: build
+	docker build -t $(NAME):$(TAG) .
+
+.PHONY: lint
+lint: $(GOLANGCI_LINT_BIN)
+	# megacheck fails to respect build flags, causing compilation failure during linting.
+	# instead, use the unused, gosimple, and staticcheck linters directly
+	$(GOLANGCI_LINT_BIN) run -D megacheck -E unused,gosimple,staticcheck
+
+dependencies: $(GOLANGCI_LINT_BIN)
+
+$(GOLANGCI_LINT_BIN):
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | sh -s -- -b $(FIRST_GOPATH)/bin v1.23.3
+

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,7 @@ github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
+github.com/google/go-cmp v0.3.1 h1:Xye71clBPdm5HgqGwUkwhbynsUJZhDbS20FvLhQ2izg=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ var opts struct {
 	PagerDutyIncidentTimeFormat        string        `long:"pagerduty.incident.timeformat"                      env:"PAGERDUTY_INCIDENT_TIMEFORMAT"                description:"PagerDuty incident time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyDisableTeams              bool          `long:"pagerduty.disable-teams"                description:"Set to true to disable checking PagerDuty teams (for plans that don't include it)"                env:"PAGERDUTY_DISABLE_TEAMS"`
 	PagerDutyTeamFilter			       []string      `long:"pagerduty.team-filter" env-delim:","                env:"PAGERDUTY_TEAM_FILTER"            description:"Passes team ID as a list option when applicable."`
-}
+}         
 
 func main() {
 	initArgparser()

--- a/main.go
+++ b/main.go
@@ -5,8 +5,6 @@ import (
 	"github.com/PagerDuty/go-pagerduty"
 	"github.com/jessevdk/go-flags"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/webdevops/pagerduty-exporter/vendor/github.com/PagerDuty/go-pagerduty"
-	"github.com/webdevops/pagerduty-exporter/vendor/github.com/jessevdk/go-flags"
 	"log"
 	"net/http"
 	"os"

--- a/main.go
+++ b/main.go
@@ -42,8 +42,8 @@ var opts struct {
 	PagerDutyScheduleEntryTimeFormat   string        `long:"pagerduty.schedule.entry-timeformat"           env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT"          description:"PagerDuty schedule entry time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyIncidentTimeFormat        string        `long:"pagerduty.incident.timeformat"                      env:"PAGERDUTY_INCIDENT_TIMEFORMAT"                description:"PagerDuty incident time format (label)" default:"Mon, 02 Jan 15:04 MST"`
 	PagerDutyDisableTeams              bool          `long:"pagerduty.disable-teams"                description:"Set to true to disable checking PagerDuty teams (for plans that don't include it)"                env:"PAGERDUTY_DISABLE_TEAMS"`
-	PagerDutyTeamFilter			       []string      `long:"pagerduty.team-filter" env-delim:","                env:"PAGERDUTY_TEAM_FILTER"            description:"Passes team ID as a list option when applicable."`
-}         
+	PagerDutyTeamFilter                []string      `long:"pagerduty.team-filter" env-delim:","                env:"PAGERDUTY_TEAM_FILTER"            description:"Passes team ID as a list option when applicable."`
+}
 
 func main() {
 	initArgparser()


### PR DESCRIPTION
Hello! My name is Jean-Francois and I work at Red Hat. We are interested in using and of course in contributing to this project. At first glace it seem to be very well implemented and complete as to what metrics we are looking to get out of Pagerduty.

In this first PR, I am proposing to add a Makefile to the repo. This will be helpful in a couple of ways:
- Be the source of truth for building, running, validating/linting, testing the code
- Commands from the makefile can then be executed uniformly across local environments, CI, etc..
- Helps with building container images, tagged with the current commit has at HEAD for dev and testing purposes
- It has a `lint` target is helpful to run in CI tests to ensure the code is following proper conventions. It has already found a couple of things that I would like to fix in a future PR if that's OK.

The PR also updates the imports in main.go as the ones from the vendor directory seem to be unnecessary.

Hopefully you are open to external contributions. Thanks!