### PR TITLE
Go linter fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,8 @@ FROM golang:1.14 as build
 
 WORKDIR /go/src/github.com/webdevops/pagerduty-exporter
 
+RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.23.8
+
 # Get deps (cached)
 COPY ./go.mod /go/src/github.com/webdevops/pagerduty-exporter
 COPY ./go.sum /go/src/github.com/webdevops/pagerduty-exporter
@@ -12,6 +14,7 @@ COPY ./ /go/src/github.com/webdevops/pagerduty-exporter
 RUN CGO_ENABLED=0 GOOS=linux go build -a -ldflags '-extldflags "-static"' -o /pagerduty-exporter \
     && chmod +x /pagerduty-exporter
 RUN /pagerduty-exporter --help
+RUN golangci-lint run -D megacheck -E unused,gosimple,staticcheck
 
 #############################################
 # FINAL IMAGE

--- a/collector_base.go
+++ b/collector_base.go
@@ -67,7 +67,7 @@ func (c *CollectorBase) PrometheusStatsGauge() *prometheus.GaugeVec {
 	return collectorGlobal.prometheus.stats
 }
 
-func (c *CollectorBase) PrometheusApiCounter() *prometheus.CounterVec {
+func (c *CollectorBase) PrometheusAPICounter() *prometheus.CounterVec {
 	if collectorGlobal.prometheus.api == nil {
 		collectorGlobal.prometheus.apiMutex.Lock()
 

--- a/collector_base.go
+++ b/collector_base.go
@@ -92,7 +92,7 @@ func (c *CollectorBase) collectionStart() {
 	c.collectionStartTime = time.Now()
 
 	if !c.isHidden {
-		Logger.Infof("collector[%s]: starting metrics collection", c.Name)
+		daemonLogger.Infof("collector[%s]: starting metrics collection", c.Name)
 	}
 }
 
@@ -101,13 +101,13 @@ func (c *CollectorBase) collectionFinish() {
 	c.LastScrapeDuration = &duration
 
 	if !c.isHidden {
-		Logger.Infof("collector[%s]: finished metrics collection (duration: %v)", c.Name, c.LastScrapeDuration)
+		daemonLogger.Infof("collector[%s]: finished metrics collection (duration: %v)", c.Name, c.LastScrapeDuration)
 	}
 }
 
 func (c *CollectorBase) sleepUntilNextCollection() {
 	if !c.isHidden {
-		Logger.Verbosef("collector[%s]: sleeping %v", c.Name, c.GetScrapeTime().String())
+		daemonLogger.Verbosef("collector[%s]: sleeping %v", c.Name, c.GetScrapeTime().String())
 	}
 	time.Sleep(*c.GetScrapeTime())
 }

--- a/collector_base.go
+++ b/collector_base.go
@@ -15,7 +15,6 @@ type CollectorBase struct {
 	LastScrapeDuration  *time.Duration
 	collectionStartTime time.Time
 
-	errorCounter int
 	isHidden     bool
 }
 

--- a/collector_general.go
+++ b/collector_general.go
@@ -33,8 +33,8 @@ func (m *CollectorGeneral) Collect() {
 		if r := recover(); r != nil {
 			m.errorCounter++
 
-			Logger.Error(r)
-			if m.errorCounter > COLLECTOR_ERROR_THRESHOLD {
+			daemonLogger.Error(r)
+			if m.errorCounter > CollectorErrorThreshold {
 				panic("Error threshold reached, stopping exporter")
 			}
 		}

--- a/collector_general.go
+++ b/collector_general.go
@@ -12,6 +12,7 @@ type CollectorGeneral struct {
 	Processor CollectorProcessorGeneralInterface
 
 	PagerDutyClient *pagerduty.Client
+	errorCounter int
 }
 
 func (m *CollectorGeneral) Run(scrapeTime time.Duration) {

--- a/logger.go
+++ b/logger.go
@@ -11,7 +11,7 @@ type DaemonLogger struct {
 	verbose bool
 }
 
-func NewLogger(flags int, verbose bool) *DaemonLogger {
+func NewDaemonLogger(flags int, verbose bool) *DaemonLogger {
 	instance := &DaemonLogger{
 		Logger:  logger.Init("Verbose", true, false, ioutil.Discard),
 		verbose: verbose,

--- a/main.go
+++ b/main.go
@@ -14,14 +14,14 @@ import (
 )
 
 const (
-	Author                    = "webdevops.io"
-	Version                   = "0.11.0"
+	author                    = "webdevops.io"
+	version                   = "0.11.0"
 
 	// PagerdutyListLimit limits the amount of items returned from an API query
 	PagerdutyListLimit = 100
 
 	// Number of failed fetches in a row before stopping the exporter
-	COLLECTOR_ERROR_THRESHOLD = 5
+	CollectorErrorThreshold = 5
 )
 
 var (

--- a/main.go
+++ b/main.go
@@ -23,7 +23,7 @@ const (
 var (
 	argparser            *flags.Parser
 	args                 []string
-	Verbose              bool
+	verbose              bool
 	Logger               *DaemonLogger
 	PagerDutyClient      *pagerduty.Client
 	collectorGeneralList map[string]*CollectorGeneral
@@ -53,13 +53,13 @@ func main() {
 	initArgparser()
 
 	// set verbosity
-	Verbose = len(opts.Verbose) >= 1
+	verbose = len(opts.Verbose) >= 1
 
 	// Init logger
-	Logger = NewLogger(log.Lshortfile, Verbose)
+	Logger = NewLogger(log.Lshortfile, verbose)
 	defer Logger.Close()
 
-	Logger.Infof("Init Pagerduty exporter v%s (written by %v)", Version, Author)
+	Logger.Infof("Init Pagerduty exporter v%s (written by %v)", version, author)
 
 	Logger.Infof("Init PagerDuty client")
 	initPagerDuty()

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ func main() {
 	initMetricCollector()
 
 	daemonLogger.Infof("Starting http server on %s", opts.ServerBind)
-	startHttpServer()
+	startHTTPServer()
 }
 
 // init argparser and parse/validate arguments
@@ -183,7 +183,7 @@ func initMetricCollector() {
 }
 
 // start and handle prometheus handler
-func startHttpServer() {
+func startHTTPServer() {
 	http.Handle("/metrics", promhttp.Handler())
 	daemonLogger.Fatal(http.ListenAndServe(opts.ServerBind, nil))
 }

--- a/main.go
+++ b/main.go
@@ -27,7 +27,7 @@ const (
 var (
 	argparser            *flags.Parser
 	verbose              bool
-	Logger               *DaemonLogger
+	daemonLogger         *DaemonLogger
 	PagerDutyClient      *pagerduty.Client
 	collectorGeneralList map[string]*CollectorGeneral
 )
@@ -59,20 +59,20 @@ func main() {
 	verbose = len(opts.Verbose) >= 1
 
 	// Init logger
-	Logger = NewLogger(log.Lshortfile, verbose)
-	defer Logger.Close()
+	daemonLogger = NewDaemonLogger(log.Lshortfile, verbose)
+	defer daemonLogger.Close()
 
-	Logger.Infof("Init Pagerduty exporter v%s (written by %v)", version, author)
+	daemonLogger.Infof("Init Pagerduty exporter v%s (written by %v)", version, author)
 
-	Logger.Infof("Init PagerDuty client")
+	daemonLogger.Infof("Init PagerDuty client")
 	initPagerDuty()
 
-	Logger.Infof("Starting metrics collection")
-	Logger.Infof("  scape time: %v", opts.ScrapeTime)
-	Logger.Infof("  scape time live: %v", opts.ScrapeTimeLive)
+	daemonLogger.Infof("Starting metrics collection")
+	daemonLogger.Infof("  scape time: %v", opts.ScrapeTime)
+	daemonLogger.Infof("  scape time live: %v", opts.ScrapeTimeLive)
 	initMetricCollector()
 
-	Logger.Infof("Starting http server on %s", opts.ServerBind)
+	daemonLogger.Infof("Starting http server on %s", opts.ServerBind)
 	startHttpServer()
 }
 
@@ -124,7 +124,7 @@ func initMetricCollector() {
 			collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorTeam{})
 			collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 		} else {
-			Logger.Infof("collector[%s]: disabled", collectorName)
+			daemonLogger.Infof("collector[%s]: disabled", collectorName)
 		}
 	}
 
@@ -133,7 +133,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorUser{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "Service"
@@ -141,7 +141,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorService{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "Schedule"
@@ -149,7 +149,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorSchedule{})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "MaintenanceWindow"
@@ -157,7 +157,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorMaintenanceWindow{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTime)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "OnCall"
@@ -165,7 +165,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorOncall{})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTimeLive)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "Incident"
@@ -173,7 +173,7 @@ func initMetricCollector() {
 		collectorGeneralList[collectorName] = NewCollectorGeneral(collectorName, &MetricsCollectorIncident{teamListOpt: opts.PagerDutyTeamFilter})
 		collectorGeneralList[collectorName].Run(opts.ScrapeTimeLive)
 	} else {
-		Logger.Infof("collector[%s]: disabled", collectorName)
+		daemonLogger.Infof("collector[%s]: disabled", collectorName)
 	}
 
 	collectorName = "Collector"
@@ -185,5 +185,5 @@ func initMetricCollector() {
 // start and handle prometheus handler
 func startHttpServer() {
 	http.Handle("/metrics", promhttp.Handler())
-	Logger.Fatal(http.ListenAndServe(opts.ServerBind, nil))
+	daemonLogger.Fatal(http.ListenAndServe(opts.ServerBind, nil))
 }

--- a/main.go
+++ b/main.go
@@ -22,7 +22,6 @@ const (
 
 var (
 	argparser            *flags.Parser
-	args                 []string
 	verbose              bool
 	Logger               *DaemonLogger
 	PagerDutyClient      *pagerduty.Client

--- a/main.go
+++ b/main.go
@@ -16,7 +16,11 @@ import (
 const (
 	Author                    = "webdevops.io"
 	Version                   = "0.11.0"
-	PAGERDUTY_LIST_LIMIT      = 100
+
+	// PagerdutyListLimit limits the amount of items returned from an API query
+	PagerdutyListLimit = 100
+
+	// Number of failed fetches in a row before stopping the exporter
 	COLLECTOR_ERROR_THRESHOLD = 5
 )
 

--- a/metrics_incident.go
+++ b/metrics_incident.go
@@ -80,7 +80,7 @@ func (m *MetricsCollectorIncident) Collect(ctx context.Context, callback chan<- 
 		daemonLogger.Verbosef(" - fetch incidents (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListIncidents(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListIncidents").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListIncidents").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_incident.go
+++ b/metrics_incident.go
@@ -65,7 +65,7 @@ func (m *MetricsCollectorIncident) Reset() {
 
 func (m *MetricsCollectorIncident) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListIncidentsOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Statuses = []string{"triggered", "acknowledged"}
 	listOpts.Offset = 0
 

--- a/metrics_incident.go
+++ b/metrics_incident.go
@@ -77,7 +77,7 @@ func (m *MetricsCollectorIncident) Collect(ctx context.Context, callback chan<- 
 	incidentStatusMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch incidents (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch incidents (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListIncidents(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListIncidents").Inc()

--- a/metrics_maintenance_window.go
+++ b/metrics_maintenance_window.go
@@ -55,7 +55,7 @@ func (m *MetricsCollectorMaintenanceWindow) Reset() {
 
 func (m *MetricsCollectorMaintenanceWindow) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListMaintenanceWindowsOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Offset = 0
 
 	if len(m.teamListOpt) > 0 {

--- a/metrics_maintenance_window.go
+++ b/metrics_maintenance_window.go
@@ -66,7 +66,7 @@ func (m *MetricsCollectorMaintenanceWindow) Collect(ctx context.Context, callbac
 	maintWindowsStatusMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch maintenance windows (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch maintenance windows (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListMaintenanceWindows(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListMaintenanceWindows").Inc()

--- a/metrics_maintenance_window.go
+++ b/metrics_maintenance_window.go
@@ -69,7 +69,7 @@ func (m *MetricsCollectorMaintenanceWindow) Collect(ctx context.Context, callbac
 		daemonLogger.Verbosef(" - fetch maintenance windows (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListMaintenanceWindows(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListMaintenanceWindows").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListMaintenanceWindows").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_oncall.go
+++ b/metrics_oncall.go
@@ -35,7 +35,7 @@ func (m *MetricsCollectorOncall) Reset() {
 
 func (m *MetricsCollectorOncall) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListOnCallOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Earliest = true
 	listOpts.Offset = 0
 

--- a/metrics_oncall.go
+++ b/metrics_oncall.go
@@ -45,7 +45,7 @@ func (m *MetricsCollectorOncall) Collect(ctx context.Context, callback chan<- fu
 		daemonLogger.Verbosef(" - fetch schedule oncalls (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListOnCalls(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListOnCalls").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListOnCalls").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_oncall.go
+++ b/metrics_oncall.go
@@ -42,7 +42,7 @@ func (m *MetricsCollectorOncall) Collect(ctx context.Context, callback chan<- fu
 	onCallMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch schedule oncalls (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch schedule oncalls (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListOnCalls(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListOnCalls").Inc()

--- a/metrics_schedule.go
+++ b/metrics_schedule.go
@@ -111,7 +111,7 @@ func (m *MetricsCollectorSchedule) Collect(ctx context.Context, callback chan<- 
 	scheduleMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef("fetch schedules (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef("fetch schedules (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListSchedules(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListSchedules").Inc()
@@ -160,7 +160,7 @@ func (m *MetricsCollectorSchedule) collectScheduleInformation(scheduleId string,
 	listOpts.Until = filterUntil.Format(time.RFC3339)
 	listOpts.Offset = 0
 
-	Logger.Verbosef("fetch schedule information (schedule: %v, offset: %v, limit:%v)", scheduleId, listOpts.Offset, listOpts.Limit)
+	daemonLogger.Verbosef("fetch schedule information (schedule: %v, offset: %v, limit:%v)", scheduleId, listOpts.Offset, listOpts.Limit)
 
 	schedule, err := PagerDutyClient.GetSchedule(scheduleId, listOpts)
 	m.CollectorReference.PrometheusApiCounter().WithLabelValues("GetSchedule").Inc()
@@ -265,7 +265,7 @@ func (m *MetricsCollectorSchedule) collectScheduleOverrides(scheduleId string, c
 	overrideMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef("fetch schedule overrides (schedule: %v, offset: %v, limit:%v)", scheduleId, listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef("fetch schedule overrides (schedule: %v, offset: %v, limit:%v)", scheduleId, listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListOverrides(scheduleId, listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListOverrides").Inc()

--- a/metrics_schedule.go
+++ b/metrics_schedule.go
@@ -105,7 +105,7 @@ func (m *MetricsCollectorSchedule) Collect(ctx context.Context, callback chan<- 
 	var wg sync.WaitGroup
 
 	listOpts := pagerduty.ListSchedulesOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Offset = 0
 
 	scheduleMetricList := MetricCollectorList{}
@@ -155,7 +155,7 @@ func (m *MetricsCollectorSchedule) collectScheduleInformation(scheduleId string,
 	filterUntil := time.Now().Add(opts.PagerDutyScheduleEntryTimeframe)
 
 	listOpts := pagerduty.GetScheduleOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Since = filterSince.Format(time.RFC3339)
 	listOpts.Until = filterUntil.Format(time.RFC3339)
 	listOpts.Offset = 0
@@ -257,7 +257,7 @@ func (m *MetricsCollectorSchedule) collectScheduleOverrides(scheduleId string, c
 	filterUntil := time.Now().Add(opts.PagerDutyScheduleOverrideTimeframe)
 
 	listOpts := pagerduty.ListOverridesOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Since = filterSince.Format(time.RFC3339)
 	listOpts.Until = filterUntil.Format(time.RFC3339)
 	listOpts.Offset = 0

--- a/metrics_service.go
+++ b/metrics_service.go
@@ -51,7 +51,7 @@ func (m *MetricsCollectorService) Collect(ctx context.Context, callback chan<- f
 	serviceMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch services (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch services (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListServices(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListServices").Inc()

--- a/metrics_service.go
+++ b/metrics_service.go
@@ -41,7 +41,7 @@ func (m *MetricsCollectorService) Reset() {
 
 func (m *MetricsCollectorService) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListServiceOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Offset = 0
 
 	if len(m.teamListOpt) > 0 {

--- a/metrics_service.go
+++ b/metrics_service.go
@@ -54,7 +54,7 @@ func (m *MetricsCollectorService) Collect(ctx context.Context, callback chan<- f
 		daemonLogger.Verbosef(" - fetch services (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListServices(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListServices").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListServices").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_team.go
+++ b/metrics_team.go
@@ -38,7 +38,7 @@ func (m *MetricsCollectorTeam) Reset() {
 
 func (m *MetricsCollectorTeam) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListTeamOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Offset = 0
 
 	teamMetricList := MetricCollectorList{}

--- a/metrics_team.go
+++ b/metrics_team.go
@@ -47,7 +47,7 @@ func (m *MetricsCollectorTeam) Collect(ctx context.Context, callback chan<- func
 		daemonLogger.Verbosef(" - fetch teams (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListTeams(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListTeams").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListTeams").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_team.go
+++ b/metrics_team.go
@@ -44,7 +44,7 @@ func (m *MetricsCollectorTeam) Collect(ctx context.Context, callback chan<- func
 	teamMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch teams (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch teams (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListTeams(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListTeams").Inc()

--- a/metrics_user.go
+++ b/metrics_user.go
@@ -58,7 +58,7 @@ func (m *MetricsCollectorUser) Collect(ctx context.Context, callback chan<- func
 		daemonLogger.Verbosef(" - fetch users (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListUsers(listOpts)
-		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListUsers").Inc()
+		m.CollectorReference.PrometheusAPICounter().WithLabelValues("ListUsers").Inc()
 
 		if err != nil {
 			panic(err)

--- a/metrics_user.go
+++ b/metrics_user.go
@@ -45,7 +45,7 @@ func (m *MetricsCollectorUser) Reset() {
 
 func (m *MetricsCollectorUser) Collect(ctx context.Context, callback chan<- func()) {
 	listOpts := pagerduty.ListUsersOptions{}
-	listOpts.Limit = PAGERDUTY_LIST_LIMIT
+	listOpts.Limit = PagerdutyListLimit
 	listOpts.Offset = 0
 
 	if len(m.teamListOpt) > 0 {

--- a/metrics_user.go
+++ b/metrics_user.go
@@ -55,7 +55,7 @@ func (m *MetricsCollectorUser) Collect(ctx context.Context, callback chan<- func
 	userMetricList := MetricCollectorList{}
 
 	for {
-		Logger.Verbosef(" - fetch users (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
+		daemonLogger.Verbosef(" - fetch users (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
 
 		list, err := PagerDutyClient.ListUsers(listOpts)
 		m.CollectorReference.PrometheusApiCounter().WithLabelValues("ListUsers").Inc()

--- a/misc.go
+++ b/misc.go
@@ -12,21 +12,6 @@ func boolToString(b bool) string {
 	return "false"
 }
 
-func boolToFloat64(b bool) float64 {
-	if b {
-		return 1
-	}
-	return 0
-}
-
-func intToString(v int) string {
-	return strconv.FormatInt(int64(v), 10)
-}
-
-func int64ToString(v int64) string {
-	return strconv.FormatInt(v, 10)
-}
-
 func uintToString(v uint) string {
 	return strconv.FormatUint(uint64(v), 10)
 }


### PR DESCRIPTION
- Rename globa/uppercase variable to CamelCase & exported + added comment
- Proper CamelCase naming
- unexport variables that don't need exporting (logger, version)
- rename Logger var to daemonLogger, primarily to avoid conflicting with google/logger import

The only remaining Lint warnings are for all exported functions (starting with uppercase letter) what should all have a comment to describe what they do. Once this is done we can generate docs for everything