### PR TITLE
Add commandline option to disable schedule-related metrics

### DIFF
--- a/config/opts.go
+++ b/config/opts.go
@@ -22,6 +22,7 @@ type (
 			MaxConnections int    `long:"pagerduty.max-connections"                env:"PAGERDUTY_MAX_CONNECTIONS"                    description:"Maximum numbers of TCP connections to PagerDuty API (concurrency)" default:"4"`
 
 			Schedule struct {
+				Disable           bool          `long:"pagerduty.disable-schedule"               env:"PAGERDUTY_DISABLE_SCHEDULES"                  description:"Set to true to disable exposing schedule metrics"`
 				OverrideTimeframe time.Duration `long:"pagerduty.schedule.override-duration"     env:"PAGERDUTY_SCHEDULE_OVERRIDE_TIMEFRAME"        description:"PagerDuty timeframe for fetching schedule overrides (time.Duration)" default:"48h"`
 				EntryTimeframe    time.Duration `long:"pagerduty.schedule.entry-timeframe"       env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFRAME"           description:"PagerDuty timeframe for fetching schedule entries (time.Duration)" default:"72h"`
 				EntryTimeFormat   string        `long:"pagerduty.schedule.entry-timeformat"      env:"PAGERDUTY_SCHEDULE_ENTRY_TIMEFORMAT"          description:"PagerDuty schedule entry time format (label)" default:"Mon, 02 Jan 15:04 MST"`

--- a/main.go
+++ b/main.go
@@ -191,15 +191,17 @@ func initMetricCollector() {
 
 	}
 
-	collectorName = "Schedule"
-	if opts.ScrapeTime.General.Seconds() > 0 {
-		c := collector.New(collectorName, &MetricsCollectorSchedule{}, log.StandardLogger())
-		c.SetScapeTime(opts.ScrapeTime.General)
-		if err := c.Start(); err != nil {
-			log.Panic(err.Error())
+	if !opts.PagerDuty.Schedule.Disable {
+		collectorName = "Schedule"
+		if opts.ScrapeTime.General.Seconds() > 0 {
+			c := collector.New(collectorName, &MetricsCollectorSchedule{}, log.StandardLogger())
+			c.SetScapeTime(opts.ScrapeTime.General)
+			if err := c.Start(); err != nil {
+				log.Panic(err.Error())
+			}
+		} else {
+			log.WithField("collector", collectorName).Infof("collector disabled")
 		}
-	} else {
-		log.WithField("collector", collectorName).Infof("collector disabled")
 	}
 
 	collectorName = "MaintenanceWindow"
@@ -213,15 +215,17 @@ func initMetricCollector() {
 		log.WithField("collector", collectorName).Infof("collector disabled")
 	}
 
-	collectorName = "OnCall"
-	if opts.ScrapeTime.Live.Seconds() > 0 {
-		c := collector.New(collectorName, &MetricsCollectorOncall{}, log.StandardLogger())
-		c.SetScapeTime(opts.ScrapeTime.Live)
-		if err := c.Start(); err != nil {
-			log.Panic(err.Error())
+	if !opts.PagerDuty.Schedule.Disable {
+		collectorName = "OnCall"
+		if opts.ScrapeTime.Live.Seconds() > 0 {
+			c := collector.New(collectorName, &MetricsCollectorOncall{}, log.StandardLogger())
+			c.SetScapeTime(opts.ScrapeTime.Live)
+			if err := c.Start(); err != nil {
+				log.Panic(err.Error())
+			}
+		} else {
+			log.WithField("collector", collectorName).Infof("collector disabled")
 		}
-	} else {
-		log.WithField("collector", collectorName).Infof("collector disabled")
 	}
 
 	collectorName = "Incident"


### PR DESCRIPTION
Schedule metrics can be quite verbose for larger pagerduty accounts. Add an option to disable the pagerduty_schedule_* metrics at runtime.

This will allow users to cut down on cardinality and metrics that aren't needed for their usecase.

For an example in my particular environment
Without the disable-schedule flag set
```
$ curl localhost:8080/metrics | wc -l
    7477
```
With the disable-schedule flag set
```
$ curl localhost:8080/metrics | wc -l
     720
```