### PR TITLE
Add pagerduty_summary_incident_acknowledge_duration metric to summary

### DIFF
--- a/metrics_summary.go
+++ b/metrics_summary.go
@@ -202,14 +202,7 @@ func (m *MetricsCollectorSummary) collectIncidents(callback chan<- func()) {
 						"urgency":   incident.Urgency,
 						"priority":  incidentPriority,
 					})
-				} else if resolvedAt.After(*m.GetLastScapeTime()) {
-					changedIncidentCountMetricList.Inc(prometheus.Labels{
-						"serviceID": incident.Service.ID,
-						"status":    incident.Status,
-						"urgency":   incident.Urgency,
-						"priority":  incidentPriority,
-					})
-				} else if acknowledgedAt.After(*m.GetLastScapeTime()) {
+				} else if acknowledgedAt.After(*m.GetLastScapeTime()) || resolvedAt.After(*m.GetLastScapeTime()) {
 					changedIncidentCountMetricList.Inc(prometheus.Labels{
 						"serviceID": incident.Service.ID,
 						"status":    incident.Status,


### PR DESCRIPTION
Hello!

We have more-or-less copy-pasted the resolved metric and added an acknowledge metric because we needed that metric as well.

PagerDuty doesn't expose an "acknowledgedAt" field, so instead we infer it by finding the first acknowledgement,  chronologically, and use that timestamp.

If an incident has been resolved it counts both for pagerduty_summary_incident_acknowledge_duration and pagerduty_summary_incident_resolve_duration.