### PR TITLE
feat(team): add pagerduty_team_member_info metric to expose team members and their roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ This will run the container locally, mapping container port 8080 to local port 8
 | `pagerduty_stats`                                | Collector         | Collector stats                                                                                                      |
 | `pagerduty_api_counter`                          | Collector         | PagerDuty api call counter                                                                                           |
 | `pagerduty_team_info`                            | Team              | Team information                                                                                                     |
+| `pagerduty_team_member_info`                     | Team              | Team members and their team role                                                                                     |
 | `pagerduty_user_info`                            | User              | User information                                                                                                     |
 | `pagerduty_service_info`                         | Service           | Service (per team) information                                                                                       |
 | `pagerduty_maintenancewindow_info`               | MaintenanceWindow | Maintenance window information                                                                                       |
@@ -128,4 +129,10 @@ bottomk(1,
     * on (userID) group_left(userName) (pagerduty_user_info)
   ) - time() > 0
 )
+```
+
+Team members
+```
+pagerduty_team_member_info{teamID="$TEAM_ID"}
+* on(userID) group_left(userName) pagerduty_user_info
 ```

--- a/metrics_team.go
+++ b/metrics_team.go
@@ -10,7 +10,8 @@ type MetricsCollectorTeam struct {
 	collector.Processor
 
 	prometheus struct {
-		team *prometheus.GaugeVec
+		team       *prometheus.GaugeVec
+		teamMember *prometheus.GaugeVec
 	}
 }
 
@@ -29,6 +30,17 @@ func (m *MetricsCollectorTeam) Setup(collector *collector.Collector) {
 		},
 	)
 	m.Collector.RegisterMetricList("pagerduty_team_info", m.prometheus.team, true)
+
+	m.prometheus.teamMember = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "pagerduty_team_member_info",
+			Help: "PagerDuty team member information",
+		},
+		[]string{
+			"teamID", "userID", "role",
+		},
+	)
+	m.Collector.RegisterMetricList("pagerduty_team_member_info", m.prometheus.teamMember, true)
 }
 
 func (m *MetricsCollectorTeam) Reset() {
@@ -40,6 +52,7 @@ func (m *MetricsCollectorTeam) Collect(callback chan<- func()) {
 	listOpts.Offset = 0
 
 	teamMetricList := m.Collector.GetMetricList("pagerduty_team_info")
+	teamMembersMetricList := m.Collector.GetMetricList("pagerduty_team_member_info")
 
 	for {
 		m.Logger().Debugf("fetch teams (offset: %v, limit:%v)", listOpts.Offset, listOpts.Limit)
@@ -57,6 +70,20 @@ func (m *MetricsCollectorTeam) Collect(callback chan<- func()) {
 				"teamName": team.Name,
 				"teamUrl":  team.HTMLURL,
 			})
+
+			members, err := PagerDutyClient.ListTeamMembersPaginated(m.Context(), team.ID)
+			PrometheusPagerDutyApiCounter.WithLabelValues("ListTeamMemberships").Inc()
+			if err != nil {
+				m.Logger().Errorf("error fetching team members for team %s: %v", team.ID, err)
+				break
+			}
+			for _, member := range members {
+				teamMembersMetricList.AddInfo(prometheus.Labels{
+					"teamID": team.ID,
+					"userID": member.User.ID,
+					"role":   member.Role,
+				})
+			}
 		}
 
 		listOpts.Offset += list.Limit


### PR DESCRIPTION
Hi team,(@mblaschke)

we would like to extend your helpful tool a bit and started with exposing memberships of teams. I hope you accept direct contributions without prior discussion; please let me know if you prefer a different process for feature proposals.

---

### Summary

This PR adds the new Prometheus metric `pagerduty_team_member_info` which exposes all PagerDuty team members and their roles within each team.  
It enables users to visualize which users are in which teams and their team role, and to join this data with `pagerduty_user_info` for enhanced dashboards and queries.

### Changes

- Introduced `pagerduty_team_member_info` metric (`labels: teamID, userID, role`) to the Team collector.
- Updated `metrics_team.go`:
  - Registered new GaugeVec for this metric in `Setup`.
  - Populated the metric in `Collect` by listing all team members via PagerDuty API.
- Updated README:
  - Documented the new metric in the [Metrics](#metrics) table.
  - Added a usage example of querying and joining with `pagerduty_user_info` for Grafana dashboards or Prometheus queries.

### Example Usage

Prometheus query to show team members and their user info:
```promql
pagerduty_team_member_info{teamID="$TEAM_ID"}
* on(userID) group_left(userName) pagerduty_user_info
```

### Motivation

This feature allows for:
- Easy inspection of team membership and roles from Prometheus metrics alone.
- Building detailed Grafana dashboards/table panels of team structure.
- Automation and audits based on PagerDuty team membership.

---

### Testing

Tested locally; new metric successfully appears in `/metrics` endpoint output.

```
# HELP pagerduty_api_counter Pagerduty api counter
# TYPE pagerduty_api_counter counter
...
pagerduty_api_counter{name="ListTeamMemberships"} ...

# HELP pagerduty_team_member_info PagerDuty team member information
# TYPE pagerduty_team_member_info gauge
pagerduty_team_member_info{role="manager",teamID="P0...X",userID="P....9"} 1
pagerduty_team_member_info{role="manager",teamID="P0...Q",userID="P....7"} 1
```